### PR TITLE
Fix issue with repair by name not working on invalid profiles

### DIFF
--- a/lib/sigh/runner.rb
+++ b/lib/sigh/runner.rb
@@ -54,7 +54,7 @@ module Sigh
     # Fetches a profile matching the user's search requirements
     def fetch_profiles
       Helper.log.info "Fetching profiles..."
-      results = profile_type.find_by_bundle_id(Sigh.config[:app_identifier]).find_all(&:valid?)
+      results = profile_type.find_by_bundle_id(Sigh.config[:app_identifier])
 
       # Take the provisioning profile name into account
       if Sigh.config[:provisioning_name].to_s.length > 0


### PR DESCRIPTION
fetch_profiles needs to return all profiles, not just valid ones, to properly support action "repair"