### PR TITLE
Allow to specify custom entitlement

### DIFF
--- a/lib/sigh/resign.rb
+++ b/lib/sigh/resign.rb
@@ -5,17 +5,17 @@ module Sigh
   class Resign
     def run(options, args)
       # get the command line inputs and parse those into the vars we need...
-      ipa, signing_identity, provisioning_profiles = get_inputs(options, args)
 
+      ipa, signing_identity, provisioning_profiles, entitlements = get_inputs(options, args)
       # ... then invoke our programmatic interface with these vars
-      resign(ipa, signing_identity, provisioning_profiles)
+      resign(ipa, signing_identity, provisioning_profiles, entitlements)
     end
 
-    def self.resign(ipa, signing_identity, provisioning_profiles)
-      self.new.resign(ipa, signing_identity, provisioning_profiles)
+    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements)
+      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements)
     end
 
-    def resign(ipa, signing_identity, provisioning_profiles)
+    def resign(ipa, signing_identity, provisioning_profiles, entitlements)
       resign_path = find_resign_path
       signing_identity = find_signing_identity(signing_identity)
 
@@ -25,7 +25,7 @@ module Sigh
 
       # validate that we have valid values for all these params, we don't need to check signing_identity because `find_signing_identity` will only ever return a valid value
       validate_params(resign_path, ipa, provisioning_profiles)
-
+      entitlements = "-e #{entitlements}" if entitlements
       provisioning_options = provisioning_profiles.map { |fst, snd| "-p #{[fst, snd].compact.map(&:shellescape).join('=')}" }.join(' ')
 
       command = [
@@ -33,6 +33,7 @@ module Sigh
         ipa.shellescape,
         signing_identity.shellescape,
         provisioning_options, # we are aleady shellescaping this above, when we create the provisioning_options from the provisioning_profiles
+        entitlements,
         ipa.shellescape
       ].join(' ')
 
@@ -52,8 +53,9 @@ module Sigh
       ipa = args.first || find_ipa || ask('Path to ipa file: ')
       signing_identity = options.signing_identity || ask_for_signing_identity
       provisioning_profiles = options.provisioning_profile || find_provisioning_profile || ask('Path to provisioning file: ')
+      entitlements = options.entitlements || find_entitlements
 
-      return ipa, signing_identity, provisioning_profiles
+      return ipa, signing_identity, provisioning_profiles, entitlements
     end
 
     def find_resign_path
@@ -66,6 +68,10 @@ module Sigh
 
     def find_provisioning_profile
       Dir[File.join(Dir.pwd, '*.mobileprovision')].sort { |a, b| File.mtime(a) <=> File.mtime(b) }.first
+    end
+
+    def find_entitlements
+      Dir[File.join(Dir.pwd, '*.entitlements')].sort { |a, b| File.mtime(a) <=> File.mtime(b) }.first
     end
 
     def find_signing_identity(signing_identity)


### PR DESCRIPTION
This expose `-e` option of the bundled shell script (`/assets/resign.sh`) through an option `entitlement`
This is a non breaking change. If option is not specified it falls back onto current behaviour.
The problem that prompted me to submit this is following:
My app uses universal links capability. Despite the fact that locally I specify particular domains, provisioning profile up on the https://developer.apple.com specifies the value as `com.apple.developer.associated-domains: *`
When using `resign` command, by default it copies entitlements from provisioning profile which fails at iTunesConnect verification phase with message `*` is not allowed as a value for `com.apple.developer.associated-domains`
To workaround this problem and to allow more flexibility I exposed `-e` option for `/assets/resign.sh`

This also requires changes for `fastlane action resign` https://github.com/fastlane/fastlane/pull/1182